### PR TITLE
Enable div*64 and mod*64 taint unit tests.

### DIFF
--- a/taint_unit_test/generate_tests.c
+++ b/taint_unit_test/generate_tests.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 int bin_test_floating[10] = {1, 1, 1, 1, 0, 0, 0, 0, 0, 0};
 char *bin_names[10] = {"add", "sub", "mul", "div", "mod", "bwand", "bwor", "bwxor", "bwsl", "bwsr"};
@@ -23,6 +24,10 @@ int main(int argc, char **argv) {
             type_loop_end = end_all_types;
         }
         for(int j=0;j<type_loop_end;j++) {
+        int is_64bit_test = (0 == strcmp(types[j], "uint64")) ||
+                (0 == strcmp(types[j], "int64"));
+        int is_div_test = (0 == strcmp(bin_ops[i], "/"));
+        int is_mod_test = (0 == strcmp(bin_ops[i], "%"));
         char fname[64];
         FILE *cfile;
         if(signedness[j] != 0) {
@@ -43,8 +48,11 @@ int main(int argc, char **argv) {
         fprintf(cfile, "#define x_LABEL 0xCCCCCCCC\n");
         fprintf(cfile, "#define y_LABEL 0xDDDDDDDD\n");
         fprintf(cfile, "int main(int argc, char **argv) {\n");
-        fprintf(cfile, "    the_type x = (the_type)1;\n");
-        fprintf(cfile, "    the_type y = (the_type)2;\n");
+        fprintf(cfile, "    the_type x = (the_type)%s;\n",
+                (is_64bit_test && (is_div_test || is_mod_test)) ?
+                "0x3333333333333333" : "1");
+        fprintf(cfile, "    the_type y = (the_type)%s;\n",
+                (is_64bit_test && is_mod_test) ? "0x2222222222222222" : "2");
         fprintf(cfile, "    the_type z = (the_type)0;\n");
         fprintf(cfile, "    panda_taint_log(\"%s_%s\");\n", bin_names[i], types[j]);
         fprintf(cfile, "    panda_taint_label_buffer(&x, x_LABEL, sizeof(the_type));\n");

--- a/taint_unit_test/src/div_sint64.c
+++ b/taint_unit_test/src/div_sint64.c
@@ -4,7 +4,7 @@
 #define x_LABEL 0xCCCCCCCC
 #define y_LABEL 0xDDDDDDDD
 int main(int argc, char **argv) {
-    the_type x = (the_type)1;
+    the_type x = (the_type)0x3333333333333333;
     the_type y = (the_type)2;
     the_type z = (the_type)0;
     panda_taint_log("div_int64");

--- a/taint_unit_test/src/div_uint64.c
+++ b/taint_unit_test/src/div_uint64.c
@@ -4,7 +4,7 @@
 #define x_LABEL 0xCCCCCCCC
 #define y_LABEL 0xDDDDDDDD
 int main(int argc, char **argv) {
-    the_type x = (the_type)1;
+    the_type x = (the_type)0x3333333333333333;
     the_type y = (the_type)2;
     the_type z = (the_type)0;
     panda_taint_log("div_uint64");

--- a/taint_unit_test/src/mod_sint64.c
+++ b/taint_unit_test/src/mod_sint64.c
@@ -4,8 +4,8 @@
 #define x_LABEL 0xCCCCCCCC
 #define y_LABEL 0xDDDDDDDD
 int main(int argc, char **argv) {
-    the_type x = (the_type)1;
-    the_type y = (the_type)2;
+    the_type x = (the_type)0x3333333333333333;
+    the_type y = (the_type)0x2222222222222222;
     the_type z = (the_type)0;
     panda_taint_log("mod_int64");
     panda_taint_label_buffer(&x, x_LABEL, sizeof(the_type));

--- a/taint_unit_test/src/mod_uint64.c
+++ b/taint_unit_test/src/mod_uint64.c
@@ -4,8 +4,8 @@
 #define x_LABEL 0xCCCCCCCC
 #define y_LABEL 0xDDDDDDDD
 int main(int argc, char **argv) {
-    the_type x = (the_type)1;
-    the_type y = (the_type)2;
+    the_type x = (the_type)0x3333333333333333;
+    the_type y = (the_type)0x2222222222222222;
     the_type z = (the_type)0;
     panda_taint_log("mod_uint64");
     panda_taint_label_buffer(&x, x_LABEL, sizeof(the_type));

--- a/tests/taint2/run_all_tests.sh
+++ b/tests/taint2/run_all_tests.sh
@@ -62,9 +62,11 @@
 ./div_float
 ./div_sint16
 ./div_sint32
+./div_sint64
 ./div_sint8
 ./div_uint16
 ./div_uint32
+./div_uint64
 ./div_uint8
 ./label
 ./malloc
@@ -72,9 +74,11 @@
 ./memset
 ./mod_sint16
 ./mod_sint32
+./mod_sint64
 ./mod_sint8
 ./mod_uint16
 ./mod_uint32
+./mod_uint64
 ./mod_uint8
 ./mul_double
 ./mul_float
@@ -96,15 +100,6 @@
 ./sub_uint32
 ./sub_uint64
 ./sub_uint8
-
-#disabled due to failures that havent been worked through yet
-
-# these two are due to 32-bit x86 gcc calling a function to do division and mod in software
-# with all kinds of special / corner cases in the resulting taint based on input values
-#./mod_sint64
-#./mod_uint64
-#./div_sint64
-#./div_uint64
 
 # these are just not up to date
 #./eax_test


### PR DESCRIPTION
Note that generate_tests.c was updated to special case the operands for these
tests.  32-bit gcc inserts a helper function into the compiled binary to
perform 64-bit mod and div operations.  This helper has some optimizations
that shortcut the calculations in some cases.  Using specific (large) values
bypasses those optimizations which results in taint labels begin transferred
to all bytes in the destination variable.