### PR TITLE
Enable hypercalls enabled in load_plugin

### DIFF
--- a/tests/taint2/taint2_multi_arch_record_or_replay.py
+++ b/tests/taint2/taint2_multi_arch_record_or_replay.py
@@ -81,7 +81,7 @@ if __name__ == "__main__":
         panda.run()
 
     elif args.mode == "replay":
-        panda.load_plugin("taint2")
+        panda.load_plugin("taint2", args={"enable_hypercalls": True})
         panda.run_replay("taint2_tests")
 
     else:


### PR DESCRIPTION
PANDA PR [#1418](https://github.com/panda-re/panda/pull/1418) required that an argument be passed to taint2 to enable hypercalls. This breaks the `taint2_multi_Arch_record_or_replay.py` test.

This PR adds that argument to the load plugin and restores the functionality of the test.

